### PR TITLE
Support Guzzle 7 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
Guzzle 7 support was seemingly removed by accident when the library was updated.

Please re-tag a new version as well.

Thanks!